### PR TITLE
Extension Bundle Error

### DIFF
--- a/end/host.json
+++ b/end/host.json
@@ -2,6 +2,6 @@
     "version": "2.0",
     "extensionBundle": {
         "id": "Microsoft.Azure.Functions.ExtensionBundle",
-        "version": "[1.*, 2.0.0)"
+        "version": "[2.*, 3.0.0)"
     }
 }


### PR DESCRIPTION
This will resolve the following error when attempting Press F5 to start debugging the function app.

ERROR:
Referenced bundle Microsoft.Azure.Functions.ExtensionBundle of version 1.8.1 does not meet the required minimum version of 2.6.1. Update your extension bundle reference in host.json to reference 2.6.1 or later.