### PR TITLE
Update CosmosDB Package and Cosmos Client to allow MS Learn Content 'npm install' to function correctly

### DIFF
--- a/start/db.js
+++ b/start/db.js
@@ -12,7 +12,7 @@ const matches = settings.Values.AzureCosmosDBConnectionString.match(/(https.*?);
 
 if(matches && matches.length > 1) {
     endpoint = matches[1];
-    client = new CosmosClient({ endpoint, auth: { masterKey } });
+    client = new CosmosClient({ endpoint, key: masterKey });
 } else {
     console.log('Cannot locate Cosmos DB endpoint from connection string.');
 }

--- a/start/package.json
+++ b/start/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/MicrosoftDocs/mslearn-advocates.azure-functions-and-signalr.git"
   },
   "dependencies": {
-    "@azure/cosmos": "^2.1.5"
+    "@azure/cosmos": "^3.17.3"
   },
   "devDependencies": {
     "lite-server": "^2.5.3"


### PR DESCRIPTION
As per discussion https://learn.microsoft.com/en-us/answers/questions/1183353/tls-exchange-fails-between-azure-cosmos-db-and-cli

The package requires and update and so does the syntax to create the db client otherwise the `npm install` command fails